### PR TITLE
python3: convert bytes to str

### DIFF
--- a/grabserial
+++ b/grabserial
@@ -416,7 +416,7 @@ def grab(arglist, outputfd=sys.stdout):
                 cmdinput = ""
 
             # read for up to 1 second
-            x = sd.read(1)
+            x = sd.read(1).decode(sys.stdout.encoding)
 
             # see if we're supposed to stop yet
             if endtime and time.time() > endtime:


### PR DESCRIPTION
In python3 the read() will return "bytes" not "str", but the following
write() and the comparators need the type "str". Just convert
unconditionally, also works on python2.

Signed-off-by: Henning Schild <henning@hennsch.de>