### PR TITLE
python3: do not open outfile in binary mode

### DIFF
--- a/grabserial
+++ b/grabserial
@@ -370,7 +370,7 @@ def grab(arglist, outputfd=sys.stdout):
         vprint("Skipping check of serial device")
     if outputfile:
         try:
-            out = open(outputfile, "wb")
+            out = open(outputfile, "w")
         except IOError:
             print("Can't open output file '%s'" % outputfile)
             sys.exit(1)


### PR DESCRIPTION
If outfile is opened in binary mode a write can not write "str" but is
expected to write "bytes", but we are are writing "str" to it.

Tested with python2 and python3.

python3 output before the patch:
[21:01:35.184141 0.000001] Traceback (most recent call last):
  File "./grabserial", line 530, in <module>
    grab(sys.argv[1:])
  File "./grabserial", line 470, in grab
    out.write(msg)
TypeError: a bytes-like object is required, not 'str'

Signed-off-by: Henning Schild <henning@hennsch.de>