### PR TITLE
Feature rollover output filename with date pattern

### DIFF
--- a/grabserial
+++ b/grabserial
@@ -373,9 +373,8 @@ def grab(arglist, outputfd=sys.stdout):
             out_filename = arg
             if out_filename == "%":
                 out_filename = "%Y-%m-%dT%H:%M:%S"
-                out_filenamehasdate = 1
             if "%d" in out_filename:
-                out_pattern = arg
+                out_pattern = out_filename
                 out_filenamehasdate = 1
             if "%" in out_filename:
                 out_filename = datetime.datetime.now().strftime(out_filename)

--- a/grabserial
+++ b/grabserial
@@ -284,6 +284,7 @@ def grab(arglist, outputfd=sys.stdout):
     quiet = False
     systime_format = "%H:%M:%S.%f"
     use_delta = True
+    out_filenamehasdate = 0
 
     for opt, arg in opts:
         if opt in ["-h", "--help"]:
@@ -372,6 +373,10 @@ def grab(arglist, outputfd=sys.stdout):
             out_filename = arg
             if out_filename == "%":
                 out_filename = "%Y-%m-%dT%H:%M:%S"
+                out_filenamehasdate = 1
+            if "%d" in out_filename:
+                out_pattern = arg
+                out_filenamehasdate = 1
             if "%" in out_filename:
                 out_filename = datetime.datetime.now().strftime(out_filename)
         if opt in ["-A", "--append"]:
@@ -424,6 +429,8 @@ def grab(arglist, outputfd=sys.stdout):
             # open in binary mode, to pass through data as unmodified
             # as possible
             out = open(out_filename, out_permissions)
+            if out_filenamehasdate:
+                out_opendate = datetime.date.today()
         except IOError:
             print("Can't open output file '%s'" % out_filename)
             sys.exit(1)
@@ -503,6 +510,24 @@ def grab(arglist, outputfd=sys.stdout):
             # set basetime to when first char is received
             if not basetime:
                 basetime = time.time()
+
+            # if outputting data to a file with a date in its name and the
+            # date has changed, then close it and open a new file.
+            if (out_filename
+                    and out_filenamehasdate
+                    and newline
+                    and datetime.date.today() > out_opendate
+                    and not endtime):
+                vprint("Closing output file: '%s'\n" % out_filename)
+                out.close()
+                out_filename = datetime.datetime.now().strftime(out_pattern)
+                vprint("Opening new output file: '%s'\n" % out_filename)
+                try:
+                    out = open(out_filename, out_permissions)
+                    out_opendate = datetime.date.today()
+                except IOError:
+                    print("Can't open output file '%s'" % out_filename)
+                    sys.exit(1)
 
             if show_time and newline:
                 linetime = time.time()


### PR DESCRIPTION
This added logic will determine if a date substitution parameter is used in the output file name.  If it is, and the system date changes, the output file will be closed and a new one opened.

This allows for continuous logging to an output file with a roll-over effect each day - effectively a log file for each day of logging data.

A suggested file name pattern might be: <descriptive>-%Y-%m-%d
Example: -o "pooltemp-%Y-%m-%d" -A