### PR TITLE
Two minor fixes: nodelta option did not work, and a typo 

### DIFF
--- a/grabserial
+++ b/grabserial
@@ -245,6 +245,7 @@ def grab(arglist, outputfd=sys.stdout):
                 "verbose",
                 "version",
                 "quitpat=",
+                "nodelta",
                 "skip",
                 "crtonewline",
             ])

--- a/grabserial
+++ b/grabserial
@@ -128,7 +128,7 @@ options:
                            of each line is received by %s
     -F, --timeformat=<val> Specifies system time format for each received line
                            e.g.
-                           -F \"%%Y-%%m-%%d %%H:%%M%%S.%%f\"
+                           -F \"%%Y-%%m-%%d %%H:%%M:%%S.%%f\"
                            (default \"%%H:%%M:%%S.%%f\")
     -m, --match=<pat>      Specify a regular expression pattern to match to
                            set a base time.  Time values for lines after the

--- a/grabserial
+++ b/grabserial
@@ -220,7 +220,7 @@ def grab(arglist, outputfd=sys.stdout):
     try:
         opts, args = getopt.getopt(
             arglist,
-            "hli:d:b:B:w:p:s:xrfc:taTF:m:e:o:AQvVq:S", [
+            "hli:d:b:B:w:p:s:xrfc:taTF:m:e:o:AQvVq:nS", [
                 "help",
                 "launchtime",
                 "instantpat=",


### PR DESCRIPTION
Two minor fixes:
- The "-n" and "--nodelta" options (to disable delta timestamps) did not work.
- A typo in the usage help text.
