### PR TITLE
Restart after disconnect

### DIFF
--- a/grabserial
+++ b/grabserial
@@ -121,8 +121,8 @@ options:
     -t, --time             Print time for each line received.  The time is
                            when the first character of each line is
                            received by %s
-    -a, --again            Restart application after -e expires or -q is
-                           triggered.
+    -a, --again            Restart application after -e expires, -q is
+                           triggered, or the serial device is disconnected.
     -T, --systime          Print system time for each line received. The time
                            is the absolute local time when the first character
                            of each line is received by %s

--- a/grabserial
+++ b/grabserial
@@ -149,6 +149,9 @@ options:
     -V, --version          Show version number and exit
     -S, --skip             Skip sanity checking of the serial device.
                            May be needed for some devices.
+                           This option is required if you want grabserial to
+                           continue running and attemp re-connections after
+                           the serial device has been disconnected.
     -n, --nodelta          Skip printing delta between read lines.
         --crtonewline      Promote a carriage return to be treated as a
                            newline
@@ -444,23 +447,29 @@ def grab(arglist, outputfd=sys.stdout):
     curline = ""
     vprint("Use Control-C to stop...")
 
-    # pyserial does not reconfigure the device if the settings
-    # don't change from the previous ones.  This causes issues
-    # with (at least) some USB serial converters
-    # Allow user to force device reconfiguration
-    if force:
-        toggle = sd.xonxoff
-        sd.xonxoff = not toggle
-        sd.open()
-        sd.close()
-        sd.xonxoff = toggle
-    sd.open()
-    sd.flushInput()
-    sd.flushOutput()
+    try:
+        # pyserial does not reconfigure the device if the settings
+        # don't change from the previous ones.  This causes issues
+        # with (at least) some USB serial converters
+        # Allow user to force device reconfiguration
+        if force:
+            toggle = sd.xonxoff
+            sd.xonxoff = not toggle
+            sd.open()
+            sd.close()
+            sd.xonxoff = toggle
 
-    if command:
-        sd.write((command + u"\n").encode("utf8"))
-        sd.flush()
+        sd.open()
+        sd.flushInput()
+        sd.flushOutput()
+
+        if command:
+            sd.write((command + u"\n").encode("utf8"))
+            sd.flush()
+    except serial.serialutil.SerialException:
+        # This is the exception which is raised when you unplug the USB UART.
+        # Applies to both python 2 and 3 on Linux
+        stop_reason = "grabserial stopped due to a SerialException"
 
     # capture stdin to send to serial port
     try:
@@ -594,6 +603,23 @@ def grab(arglist, outputfd=sys.stdout):
             if out:
                 out.flush()
         # FIXTHIS - maybe add 'except KeyboardInterrupt' here
+        except serial.serialutil.SerialException:
+            # This is the exception which is raised when you unplug the USB
+            # UART.  Applies to both python 2 and 3 on Linux
+
+            stop_reason = "grabserial stopped due to a SerialException"
+
+            # We might get a Ctrl+C while we are sleeping, so catch that
+            try:
+                # Wait a second so we don't use excessive CPU to spin in a loop
+                # when the serial device is disconnected.
+                time.sleep(1)
+            except KeyboardInterrupt:
+                stop_reason = "grabserial stopped due to keyboard interrupt"
+
+                # An actual error, don't restart.
+                restart = False
+            break
         except EnvironmentError:
             stop_reason = "grabserial stopped due to some external error"
 

--- a/grabserial
+++ b/grabserial
@@ -212,6 +212,7 @@ def read_input():
 # you can specify your own (already open) file descriptor, or None.  This
 # would only make sense if you specified another out_filename with
 #    "-o","myoutputfilename"
+# Return value: True if we should 'restart' the program
 def grab(arglist, outputfd=sys.stdout):
     global verbose      # pylint: disable=I0011,C0103
     global cmdinput     # pylint: disable=I0011,C0103
@@ -481,14 +482,6 @@ def grab(arglist, outputfd=sys.stdout):
 
             # see if we're supposed to stop yet
             if endtime and time.time() > endtime:
-                if restart:
-                    vprint(
-                        "Restarting %s\n" %
-                        datetime.datetime.now().strftime("%H:%M:%S.%f"))
-                    if out:
-                        out.close()
-                    sd.close()
-                    os.execv(sys.executable, ['python'] + sys.argv)
                 stop_reason = "grabserial stopped due to time expiration"
                 break
 
@@ -586,14 +579,6 @@ def grab(arglist, outputfd=sys.stdout):
 
             # Exit the loop if quitpat matches
             if quitpat and re.search(quitpat, curline):
-                if restart:
-                    vprint(
-                        "Restarting %s\n" %
-                        datetime.datetime.now().strftime("%H:%M:%S.%f"))
-                    if out:
-                        out.close()
-                    sd.close()
-                    os.execv(sys.executable, ['python'] + sys.argv)
                 stop_reason = "grabserial stopped because quit pattern '" + \
                     quitpat + "' was found"
                 break
@@ -611,9 +596,16 @@ def grab(arglist, outputfd=sys.stdout):
         # FIXTHIS - maybe add 'except KeyboardInterrupt' here
         except EnvironmentError:
             stop_reason = "grabserial stopped due to some external error"
+
+            # An actual error.  We don't want to restart the program in this
+            # case, so this function will return false.
+            restart = False
             break
         except KeyboardInterrupt:
             stop_reason = "grabserial stopped due to keyboard interrupt"
+
+            # An actual error, don't restart.
+            restart = False
             break
 
     sd.close()
@@ -639,9 +631,22 @@ def grab(arglist, outputfd=sys.stdout):
 
     vprint(stop_reason)
 
+    return restart
 
 if __name__ == "__main__":
-    grab(sys.argv[1:])
+    while True:
+        restart = grab(sys.argv[1:])
+
+        # Return value is true if we should 'restart' the program
+        if restart:
+            vprint(
+                "Restarting %s\n" %
+                datetime.datetime.now().strftime("%H:%M:%S.%f"))
+
+            # Actually restart
+            os.execv(sys.executable, ['python'] + sys.argv)
+        else:
+            break
 
 # emacs custom variables for using tabs
 # indent-tabs-mode: nil

--- a/grabserial
+++ b/grabserial
@@ -416,8 +416,10 @@ def grab(arglist, outputfd=sys.stdout):
     if instantpat:
         vprint("Instant pattern '%s' to report time of at end of run"
                % instantpat)
-    if quitpat:
+    if quitpat and not restart:
         vprint("Instant pattern '%s' to exit program" % quitpat)
+    if quitpat and restart:
+        vprint("Instant pattern '%s' to restart program" % quitpat)
     if skip_device_check:
         vprint("Skipping check of serial device")
     if out_filename:

--- a/grabserial
+++ b/grabserial
@@ -245,6 +245,7 @@ def grab(arglist, outputfd=sys.stdout):
                 "verbose",
                 "version",
                 "quitpat=",
+                "nodelta",
                 "skip",
                 "crtonewline",
             ])

--- a/grabserial
+++ b/grabserial
@@ -128,7 +128,7 @@ options:
                            of each line is received by %s
     -F, --timeformat=<val> Specifies system time format for each received line
                            e.g.
-                           -F \"%%Y-%%m-%%d %%H:%%M%%S.%%f\"
+                           -F \"%%Y-%%m-%%d %%H:%%M:%%S.%%f\"
                            (default \"%%H:%%M:%%S.%%f\")
     -m, --match=<pat>      Specify a regular expression pattern to match to
                            set a base time.  Time values for lines after the

--- a/grabserial
+++ b/grabserial
@@ -642,9 +642,6 @@ if __name__ == "__main__":
             vprint(
                 "Restarting %s\n" %
                 datetime.datetime.now().strftime("%H:%M:%S.%f"))
-
-            # Actually restart
-            os.execv(sys.executable, ['python'] + sys.argv)
         else:
             break
 

--- a/grabserial
+++ b/grabserial
@@ -468,7 +468,7 @@ def grab(arglist, outputfd=sys.stdout):
             sd.flush()
     except serial.serialutil.SerialException:
         # This is the exception which is raised when you unplug the USB UART.
-        # Applies to both python 2 and 3 on Linux
+        # Applies to both python 2 and 3 on Linux and Windows.
         stop_reason = "grabserial stopped due to a SerialException"
 
     # capture stdin to send to serial port
@@ -605,7 +605,7 @@ def grab(arglist, outputfd=sys.stdout):
         # FIXTHIS - maybe add 'except KeyboardInterrupt' here
         except serial.serialutil.SerialException:
             # This is the exception which is raised when you unplug the USB
-            # UART.  Applies to both python 2 and 3 on Linux
+            # UART.  Applies to both python 2 and 3 on Linux and Windows.
 
             stop_reason = "grabserial stopped due to a SerialException"
 

--- a/grabserial
+++ b/grabserial
@@ -220,7 +220,7 @@ def grab(arglist, outputfd=sys.stdout):
     try:
         opts, args = getopt.getopt(
             arglist,
-            "hli:d:b:B:w:p:s:xrfc:taTF:m:e:o:AQvVq:S", [
+            "hli:d:b:B:w:p:s:xrfc:taTF:m:e:o:AQvVq:nS", [
                 "help",
                 "launchtime",
                 "instantpat=",


### PR DESCRIPTION
Hi Tim,

(Note: this is my second pull request made today for grabserial, so it might make sense to look at the other one first.  The other one (#38 ) is also much simpler -- some minor bug fixes.)

This pull request allows grabserial to handle disconnections of the serial device.  I.e. if you have a USB UART, and you unplug it from the USB port.

- Tested on Linux, Python 2 and 3.  Tested on Windows, Python 2.  Tested that it still restarts with -q and -e options.  Tested that you can quit using Ctrl-C without causing an error when UART is disconnected or connected.  Tested that it works when the program starts with the UART disconnected, and then it is plugged in afterwards.
- Note that this "restart on disconnect" feature requires that the user specify the "-S" option, otherwise grabserial will quit when it fails to find the serial port device, because it won't exist when you unplug the UART.
- Do you want me to add another command-line option for restarting upon disconnects, or just leave it as the default behaviour (it still requires "-S")?  Perhaps the "-a" option could be modified to allow things like "-a=eqd", where 'e' means restart on timeout, 'q' for restart on quitpat, and 'd' for restart on disconnect.
- Also, the use of "restart on disconnect" requires stable device names.  I.e. when you disconnect /dev/ttyUSB2, and re-connect it, it must appear as /dev/ttyUSB2.  Stable device names can be achieved with udev rules.   Do you want me to add some text to explain these things?  Maybe in the README, because it would be a bit too much text to put in the  'usage' string.
- Let me know if you think anything in the code should be changed.

Example usage:
grabserial -S -a ...