### PR TITLE
Corrected -o behavior and fixed compatibility with -R.

### DIFF
--- a/grabserial
+++ b/grabserial
@@ -494,8 +494,13 @@ Use 'grabserial -h' for usage help."""
             if "%d" in out_filename:
                 out_filenamehasdate = 1
             if "%" in out_filename:
-                out_filename = out_filename.replace("%",
-                                 datetime.datetime.now().strftime(out_pattern))
+                if "%%" in out_filename:
+                    # %% use default out_pattern
+                    out_pattern = out_filename.replace("%%", out_pattern)
+                else:
+                    # use custom format string
+                    out_pattern = out_filename
+                out_filename = datetime.datetime.now().strftime(out_pattern)
         if opt in ["-A", "--append"]:
             out_permissions = "a+b"
             append = True


### PR DESCRIPTION
@AlphaSierraHotel  Based on [your comments](https://github.com/tbird20d/grabserial/pull/42#pullrequestreview-446092188) on the previous merge request I propose this.  
It works without any format string.
It works with "%%" default string.
It works with custom format strings.
It fixes -R by using loading `out_pattern` to re-generate the uri with timestamp later on.

Your proposal of using `== ""%"` is not correct in my opinion as you then lose the option to provide paths and extensions.

I'm not sure what should happen when -R and -o are given without time format string...

Regarding the 'nt' issue and making it agnostic, you will break compatibility when doing that.