### PR TITLE
Hex output working after testing and additional development

### DIFF
--- a/grabserial
+++ b/grabserial
@@ -655,7 +655,7 @@ Use 'grabserial -h' for usage help."""
     newline = 1
     curline = ""
     xline = b""
-    byte_count = 0
+    outline_bytecount = 0
     vprint("Use Control-C to stop...")
 
     try:
@@ -736,7 +736,7 @@ Use 'grabserial -h' for usage help."""
                 continue
 
             if hex_output:
-                byte_count += 1
+                outline_bytecount += 1
 
             # convert carriage returns to newlines.
             if x == b"\r" and not hex_output:
@@ -880,13 +880,13 @@ Use 'grabserial -h' for usage help."""
             if hex_output:
                 if not quiet:
                     outputfd.write("%02X " % ord(x))
-                    if byte_count >= max_bytes_per_line:
+                    if outline_bytecount >= max_bytes_per_line:
                         outputfd.write("\n")
 
                 if out and hex_output:
                     outbytestring = "%02X " % ord(x)
                     out.write(outbytestring.encode("utf-8"))
-                    if byte_count >= max_bytes_per_line:
+                    if outline_bytecount >= max_bytes_per_line:
                         out.write(b"\n")
             else:
                 # FIXTHIS - should I buffer the output here??
@@ -912,7 +912,7 @@ Use 'grabserial -h' for usage help."""
                 break
 
             if (x == b"\n" and not hex_output) \
-                    or (hex_output and byte_count >= max_bytes_per_line):
+                    or (hex_output and outline_bytecount >= max_bytes_per_line):
                 newline = 1
                 if basepat and re.match(basepat, curline):
                     basetime = linetime
@@ -920,7 +920,7 @@ Use 'grabserial -h' for usage help."""
                     prev1 = 0
                 curline = ""
                 xline = b""
-                byte_count = 0
+                outline_bytecount = 0
 
             sys.stdout.flush()
             if out:

--- a/grabserial
+++ b/grabserial
@@ -870,13 +870,6 @@ Use 'grabserial -h' for usage help."""
                             out_char = None
                         quit_index = 0
 
-            # If we're outputting hex, then we don't care to decode the byte
-            # In fact, decoding a single byte with "utf-8" will error for
-            # hex byte values 0x80-0xFF (128-255 decimal), resulting in
-            # out_char being a zero length string.  out_char is used as a
-            # validation in checking whether to output when reading strings
-            # so I've separated the output checks into hex_output and
-            # not hex_output blocks
             if hex_output:
                 if not quiet:
                     outputfd.write("%02X " % ord(x))

--- a/grabserial
+++ b/grabserial
@@ -873,27 +873,31 @@ Use 'grabserial -h' for usage help."""
             # If we're outputting hex, then we don't care to decode the byte
             # In fact, decoding a single byte with "utf-8" will error for
             # hex byte values 0x80-0xFF (128-255 decimal), resulting in
-            # out_char being a zero length string.
-            if not quiet and hex_output:
-                outputfd.write("%02X " % ord(x))
-                if byte_count >= max_bytes_per_line:
-                    outputfd.write("\n")
+            # out_char being a zero length string.  out_char is used as a
+            # validation in checking whether to output when reading strings
+            # so I've separated the output checks into hex_output and
+            # not hex_output blocks
+            if hex_output:
+                if not quiet:
+                    outputfd.write("%02X " % ord(x))
+                    if byte_count >= max_bytes_per_line:
+                        outputfd.write("\n")
 
-            if out and hex_output:
-                outbytestring = "%02X " % ord(x)
-                out.write(outbytestring.encode("utf-8"))
-                if byte_count >= max_bytes_per_line:
-                    out.write(b"\n")
+                if out and hex_output:
+                    outbytestring = "%02X " % ord(x)
+                    out.write(outbytestring.encode("utf-8"))
+                    if byte_count >= max_bytes_per_line:
+                        out.write(b"\n")
+            else:
+                # FIXTHIS - should I buffer the output here??
+                if not quiet and out_char:
+                    # out_char is a character
+                    outputfd.write(out_char)
 
-            # FIXTHIS - should I buffer the output here??
-            if not quiet and out_char and not hex_output:
-                # out_char is a character
-                outputfd.write(out_char)
-
-            if out and out_char and not hex_output:
-                # save bytestring data exactly as received from serial port
-                # (ie there is no 'decode' here)
-                out.write(x)
+                if out and out_char:
+                    # save bytestring data exactly as received from serial port
+                    # (ie there is no 'decode' here)
+                    out.write(x)
 
             # watch for patterns
             if inlinepat and not inlinetime and \

--- a/grabserial
+++ b/grabserial
@@ -420,6 +420,7 @@ def grab(arglist, outputfd=sys.stdout):
     use_delta = True
     out_filenamehasdate = 0
     hex_output = False
+    max_bytes_per_line = 16
 
     for opt, arg in opts:
         if opt in ["-h", "--help"]:
@@ -654,6 +655,7 @@ Use 'grabserial -h' for usage help."""
     newline = 1
     curline = ""
     xline = b""
+    byte_count = 0
     vprint("Use Control-C to stop...")
 
     try:
@@ -733,8 +735,11 @@ Use 'grabserial -h' for usage help."""
             if len(x) == 0:
                 continue
 
+            if hex_output:
+                byte_count += 1
+
             # convert carriage returns to newlines.
-            if x == b"\r":
+            if x == b"\r" and not hex_output:
                 if cr_to_nl:
                     x = b"\n"
                 else:
@@ -865,20 +870,30 @@ Use 'grabserial -h' for usage help."""
                             out_char = None
                         quit_index = 0
 
+            # If we're outputting hex, then we don't care to decode the byte
+            # In fact, decoding a single byte with "utf-8" will error for
+            # hex byte values 0x80-0xFF (128-255 decimal), resulting in
+            # out_char being a zero length string.
+            if not quiet and hex_output:
+                outputfd.write("%02X " % ord(x))
+                if byte_count >= max_bytes_per_line:
+                    outputfd.write("\n")
+
+            if out and hex_output:
+                outbytestring = "%02X " % ord(x)
+                out.write(outbytestring.encode("utf-8"))
+                if byte_count >= max_bytes_per_line:
+                    out.write(b"\n")
+
             # FIXTHIS - should I buffer the output here??
-            if not quiet and out_char:
-                if hex_output:
-                    outputfd.write("%02X " % ord(x))
-                else:
-                    # out_char is a character
-                    outputfd.write(out_char)
-            if out and out_char:
-                if hex_output:
-                    out.write("%02X " % ord(x))
-                else:
-                    # save bytestring data exactly as received from serial port
-                    # (ie there is no 'decode' here)
-                    out.write(x)
+            if not quiet and out_char and not hex_output:
+                # out_char is a character
+                outputfd.write(out_char)
+
+            if out and out_char and not hex_output:
+                # save bytestring data exactly as received from serial port
+                # (ie there is no 'decode' here)
+                out.write(x)
 
             # watch for patterns
             if inlinepat and not inlinetime and \
@@ -892,7 +907,8 @@ Use 'grabserial -h' for usage help."""
                     quitpat + "' was found"
                 break
 
-            if x == b"\n":
+            if (x == b"\n" and not hex_output) \
+                    or (hex_output and byte_count >= max_bytes_per_line):
                 newline = 1
                 if basepat and re.match(basepat, curline):
                     basetime = linetime
@@ -900,6 +916,7 @@ Use 'grabserial -h' for usage help."""
                     prev1 = 0
                 curline = ""
                 xline = b""
+                byte_count = 0
 
             sys.stdout.flush()
             if out:

--- a/grabserial
+++ b/grabserial
@@ -735,9 +735,6 @@ Use 'grabserial -h' for usage help."""
             if len(x) == 0:
                 continue
 
-            if hex_output:
-                outline_bytecount += 1
-
             # convert carriage returns to newlines.
             if x == b"\r" and not hex_output:
                 if cr_to_nl:
@@ -870,15 +867,19 @@ Use 'grabserial -h' for usage help."""
                             out_char = None
                         quit_index = 0
 
+            # hex_output uses the byte 'x' rather than the string 'out_char'
             if hex_output:
+                outline_bytecount += 1
+                outputstring = "%02X " % ord(x)
                 if not quiet:
-                    outputfd.write("%02X " % ord(x))
+                    # outputfd.write wants a string
+                    outputfd.write(outputstring)
                     if outline_bytecount >= max_bytes_per_line:
                         outputfd.write("\n")
 
-                if out and hex_output:
-                    outbytestring = "%02X " % ord(x)
-                    out.write(outbytestring.encode("utf-8"))
+                if out:
+                    # out.write wants a byte object, so we encode
+                    out.write(outputstring.encode("utf8"))
                     if outline_bytecount >= max_bytes_per_line:
                         out.write(b"\n")
             else:


### PR DESCRIPTION
Hi Tim,

I created a little test rig to work on this ~because I'm a glutton for punishment~ because I wanted to test it and see if could get it to work properly.  On a Raspberry Pi, I connected a USB-TTL Serial board from the USB port to the GPIO hardware serial port.

![RasberryPiTestRig](https://user-images.githubusercontent.com/29964368/104528870-560d3300-55d6-11eb-9d1f-ddbff3399fea.jpg)

And wrote a little script to send 256 bytes (from 0x00 to oxFF) down the wire.
```python
#!/usr/bin/python

import serial

ser = serial.Serial(
  port="/dev/ttyS0",
  baudrate = 9600,
  parity=serial.PARITY_NONE,
  stopbits=serial.STOPBITS_ONE,
  bytesize=serial.EIGHTBITS
  )

ser.reset_output_buffer()

datalist = list(range(256))
data = bytes(datalist)
ser.write(data)
```
With the hexoutput branch of grabserial listening on the USB port, I found that codes 0x80 through 0xFF were being received but discarded (not output).   It was due to the decoding of the byte using 'utf8' (which fails silently by design) and thus negates the output of the byte in later `if out_char` checks.  For `hex_output`, I separated the `out` and `not quiet` output blocks so that they were not affected by the value of `out_char`.

So with all the bytes now being output, I cleaned up the display by counting the bytes it outputs and simulating a newline after 16 bytes (an arbitrary number but easy to change).  This makes it easier to read the output and will allow for a number of other parameter options that depend on `if newline` to work as intended (eg. time stamps, log rotation)

I consider this tested and working but note that I didn't address the aspect of pattern matching at all.  This would either take additional development to make it work or adding some parameter validations to inform a user that pattern-matching and hex-output don't work together.