### PR TITLE
Hexoutput - serial timeout as previous transmission terminator

### DIFF
--- a/grabserial
+++ b/grabserial
@@ -655,7 +655,7 @@ Use 'grabserial -h' for usage help."""
     newline = 1
     curline = ""
     xline = b""
-    byte_count = 0
+    outline_bytecount = 0
     vprint("Use Control-C to stop...")
 
     try:
@@ -736,7 +736,7 @@ Use 'grabserial -h' for usage help."""
                 continue
 
             if hex_output:
-                byte_count += 1
+                outline_bytecount += 1
 
             # convert carriage returns to newlines.
             if x == b"\r" and not hex_output:
@@ -880,13 +880,13 @@ Use 'grabserial -h' for usage help."""
             if hex_output:
                 if not quiet:
                     outputfd.write("%02X " % ord(x))
-                    if byte_count >= max_bytes_per_line:
+                    if outline_bytecount >= max_bytes_per_line:
                         outputfd.write("\n")
 
                 if out and hex_output:
                     outbytestring = "%02X " % ord(x)
                     out.write(outbytestring.encode("utf-8"))
-                    if byte_count >= max_bytes_per_line:
+                    if outline_bytecount >= max_bytes_per_line:
                         out.write(b"\n")
             else:
                 # FIXTHIS - should I buffer the output here??
@@ -912,7 +912,7 @@ Use 'grabserial -h' for usage help."""
                 break
 
             if (x == b"\n" and not hex_output) \
-                    or (hex_output and byte_count >= max_bytes_per_line):
+                    or (hex_output and outline_bytecount >= max_bytes_per_line):
                 newline = 1
                 if basepat and re.match(basepat, curline):
                     basetime = linetime
@@ -920,7 +920,7 @@ Use 'grabserial -h' for usage help."""
                     prev1 = 0
                 curline = ""
                 xline = b""
-                byte_count = 0
+                outline_bytecount = 0
 
             sys.stdout.flush()
             if out:

--- a/grabserial
+++ b/grabserial
@@ -870,13 +870,6 @@ Use 'grabserial -h' for usage help."""
                             out_char = None
                         quit_index = 0
 
-            # If we're outputting hex, then we don't care to decode the byte
-            # In fact, decoding a single byte with "utf-8" will error for
-            # hex byte values 0x80-0xFF (128-255 decimal), resulting in
-            # out_char being a zero length string.  out_char is used as a
-            # validation in checking whether to output when reading strings
-            # so I've separated the output checks into hex_output and
-            # not hex_output blocks
             if hex_output:
                 if not quiet:
                     outputfd.write("%02X " % ord(x))

--- a/grabserial
+++ b/grabserial
@@ -656,6 +656,7 @@ Use 'grabserial -h' for usage help."""
     curline = ""
     xline = b""
     outline_bytecount = 0
+    hex_waitfornewdata = True
     vprint("Use Control-C to stop...")
 
     try:
@@ -733,6 +734,24 @@ Use 'grabserial -h' for usage help."""
 
             # if we didn't read anything, loop
             if len(x) == 0:
+                # if we're outputing hex and we're waiting for new data
+                # (serial timeout), consider it the end of the transmission
+                # sequence.  End the current output line, prepare for a 
+                # a new line... and then loop
+                if hex_output and not hex_waitfornewdata:
+                    if not quiet:
+                        outputfd.write("\n")
+                    if out:
+                        out.write(b"\n")
+                    newline = 1
+                    if basepat and re.match(basepat, curline):
+                        basetime = linetime
+                        elapsed = 0
+                        prev1 = 0
+                    curline = ""
+                    xline = b""
+                    outline_bytecount = 0
+                    hex_waitfornewdata = True
                 continue
 
             # convert carriage returns to newlines.
@@ -869,6 +888,7 @@ Use 'grabserial -h' for usage help."""
 
             # hex_output uses the byte 'x' rather than the string 'out_char'
             if hex_output:
+                hex_waitfornewdata = False
                 outline_bytecount += 1
                 outputstring = "%02X " % ord(x)
                 if not quiet:
@@ -909,12 +929,13 @@ Use 'grabserial -h' for usage help."""
                     or (hex_output and outline_bytecount >= max_bytes_per_line):
                 newline = 1
                 if basepat and re.match(basepat, curline):
-                    basetime = linetime
-                    elapsed = 0
-                    prev1 = 0
+                   basetime = linetime
+                   elapsed = 0
+                   prev1 = 0
                 curline = ""
                 xline = b""
                 outline_bytecount = 0
+                hex_waitfornewdata = True
 
             sys.stdout.flush()
             if out:

--- a/grabserial
+++ b/grabserial
@@ -873,27 +873,31 @@ Use 'grabserial -h' for usage help."""
             # If we're outputting hex, then we don't care to decode the byte
             # In fact, decoding a single byte with "utf-8" will error for
             # hex byte values 0x80-0xFF (128-255 decimal), resulting in
-            # out_char being a zero length string.
-            if not quiet and hex_output:
-                outputfd.write("%02X " % ord(x))
-                if byte_count >= max_bytes_per_line:
-                    outputfd.write("\n")
+            # out_char being a zero length string.  out_char is used as a
+            # validation in checking whether to output when reading strings
+            # so I've separated the output checks into hex_output and
+            # not hex_output blocks
+            if hex_output:
+                if not quiet:
+                    outputfd.write("%02X " % ord(x))
+                    if byte_count >= max_bytes_per_line:
+                        outputfd.write("\n")
 
-            if out and hex_output:
-                outbytestring = "%02X " % ord(x)
-                out.write(outbytestring.encode("utf-8"))
-                if byte_count >= max_bytes_per_line:
-                    out.write(b"\n")
+                if out and hex_output:
+                    outbytestring = "%02X " % ord(x)
+                    out.write(outbytestring.encode("utf-8"))
+                    if byte_count >= max_bytes_per_line:
+                        out.write(b"\n")
+            else:
+                # FIXTHIS - should I buffer the output here??
+                if not quiet and out_char:
+                    # out_char is a character
+                    outputfd.write(out_char)
 
-            # FIXTHIS - should I buffer the output here??
-            if not quiet and out_char and not hex_output:
-                # out_char is a character
-                outputfd.write(out_char)
-
-            if out and out_char and not hex_output:
-                # save bytestring data exactly as received from serial port
-                # (ie there is no 'decode' here)
-                out.write(x)
+                if out and out_char:
+                    # save bytestring data exactly as received from serial port
+                    # (ie there is no 'decode' here)
+                    out.write(x)
 
             # watch for patterns
             if inlinepat and not inlinetime and \

--- a/grabserial
+++ b/grabserial
@@ -420,6 +420,7 @@ def grab(arglist, outputfd=sys.stdout):
     use_delta = True
     out_filenamehasdate = 0
     hex_output = False
+    max_bytes_per_line = 16
 
     for opt, arg in opts:
         if opt in ["-h", "--help"]:
@@ -654,6 +655,7 @@ Use 'grabserial -h' for usage help."""
     newline = 1
     curline = ""
     xline = b""
+    byte_count = 0
     vprint("Use Control-C to stop...")
 
     try:
@@ -733,8 +735,11 @@ Use 'grabserial -h' for usage help."""
             if len(x) == 0:
                 continue
 
+            if hex_output:
+                byte_count += 1
+
             # convert carriage returns to newlines.
-            if x == b"\r":
+            if x == b"\r" and not hex_output:
                 if cr_to_nl:
                     x = b"\n"
                 else:
@@ -865,20 +870,30 @@ Use 'grabserial -h' for usage help."""
                             out_char = None
                         quit_index = 0
 
+            # If we're outputting hex, then we don't care to decode the byte
+            # In fact, decoding a single byte with "utf-8" will error for
+            # hex byte values 0x80-0xFF (128-255 decimal), resulting in
+            # out_char being a zero length string.
+            if not quiet and hex_output:
+                outputfd.write("%02X " % ord(x))
+                if byte_count >= max_bytes_per_line:
+                    outputfd.write("\n")
+
+            if out and hex_output:
+                outbytestring = "%02X " % ord(x)
+                out.write(outbytestring.encode("utf-8"))
+                if byte_count >= max_bytes_per_line:
+                    out.write(b"\n")
+
             # FIXTHIS - should I buffer the output here??
-            if not quiet and out_char:
-                if hex_output:
-                    outputfd.write("%02X " % ord(x))
-                else:
-                    # out_char is a character
-                    outputfd.write(out_char)
-            if out and out_char:
-                if hex_output:
-                    out.write("%02X " % ord(x))
-                else:
-                    # save bytestring data exactly as received from serial port
-                    # (ie there is no 'decode' here)
-                    out.write(x)
+            if not quiet and out_char and not hex_output:
+                # out_char is a character
+                outputfd.write(out_char)
+
+            if out and out_char and not hex_output:
+                # save bytestring data exactly as received from serial port
+                # (ie there is no 'decode' here)
+                out.write(x)
 
             # watch for patterns
             if inlinepat and not inlinetime and \
@@ -892,7 +907,8 @@ Use 'grabserial -h' for usage help."""
                     quitpat + "' was found"
                 break
 
-            if x == b"\n":
+            if (x == b"\n" and not hex_output) \
+                    or (hex_output and byte_count >= max_bytes_per_line):
                 newline = 1
                 if basepat and re.match(basepat, curline):
                     basetime = linetime
@@ -900,6 +916,7 @@ Use 'grabserial -h' for usage help."""
                     prev1 = 0
                 curline = ""
                 xline = b""
+                byte_count = 0
 
             sys.stdout.flush()
             if out:

--- a/grabserial
+++ b/grabserial
@@ -735,9 +735,6 @@ Use 'grabserial -h' for usage help."""
             if len(x) == 0:
                 continue
 
-            if hex_output:
-                outline_bytecount += 1
-
             # convert carriage returns to newlines.
             if x == b"\r" and not hex_output:
                 if cr_to_nl:
@@ -870,15 +867,19 @@ Use 'grabserial -h' for usage help."""
                             out_char = None
                         quit_index = 0
 
+            # hex_output uses the byte 'x' rather than the string 'out_char'
             if hex_output:
+                outline_bytecount += 1
+                outputstring = "%02X " % ord(x)
                 if not quiet:
-                    outputfd.write("%02X " % ord(x))
+                    # outputfd.write wants a string
+                    outputfd.write(outputstring)
                     if outline_bytecount >= max_bytes_per_line:
                         outputfd.write("\n")
 
-                if out and hex_output:
-                    outbytestring = "%02X " % ord(x)
-                    out.write(outbytestring.encode("utf-8"))
+                if out:
+                    # out.write wants a byte object, so we encode
+                    out.write(outputstring.encode("utf8"))
                     if outline_bytecount >= max_bytes_per_line:
                         out.write(b"\n")
             else:


### PR DESCRIPTION
I saw the OP on tbird20d/grabserial#50 had an issue where their periodic data transmissions were not being separated - which makes sense.  Their use case doesn't use line terminators but instead is broken up or terminated by the passing of time without serial data transmission.  This last commit/PR should resolve this by using the first serial timeout without data transmitted to indicate the end of the previous transmission -- only during hex-output of course.