### PR TITLE
Add option to avoid capturing stdin

### DIFF
--- a/grabserial
+++ b/grabserial
@@ -191,6 +191,7 @@ Options:
                            continue running and attemp re-connections after
                            the serial device has been disconnected.
     -n, --nodelta          Skip printing delta between read lines.
+    -N, --noinput          Don't capture stdin.
         --crtonewline      Promote a carriage return to be treated as a
                            newline
     -C, --command-mode     Perform a single command on the serial port, and
@@ -382,7 +383,7 @@ def grab(arglist, outputfd=sys.stdout):
     try:
         opts, args = getopt.getopt(
             arglist,
-            "hli:d:b:B:w:p:s:xrfc:E:taTF:m:e:o:AR:QvVq:nSCz", [
+            "hli:d:b:B:w:p:s:xrfc:E:taTF:m:e:o:AR:QvVq:nNSCz", [
                 "help",
                 "launchtime",
                 "inlinepat=",
@@ -413,6 +414,7 @@ def grab(arglist, outputfd=sys.stdout):
                 "version",
                 "quitpat=",
                 "nodelta",
+                "noinput",
                 "skip",
                 "crtonewline",
                 "command-mode",
@@ -468,6 +470,7 @@ def grab(arglist, outputfd=sys.stdout):
     quiet = False
     systime_format = "%H:%M:%S.%f"
     use_delta = True
+    use_input = True
     out_filenamehasdate = 0
     hex_output = False
     hex_ascii = False
@@ -623,6 +626,8 @@ Use 'grabserial -h' for usage help."""
             skip_device_check = 1
         if opt in ["-n", "--nodelta"]:
             use_delta = False
+        if opt in ["-N", "--noinput"]:
+            use_input = False
         if opt in ["--crtonewline"]:
             cr_to_nl = 1
         if opt in ["--hex-output"]:
@@ -751,11 +756,12 @@ Use 'grabserial -h' for usage help."""
         # Applies to both python 2 and 3 on Linux and Windows.
         stop_reason = "grabserial stopped due to a SerialException"
 
-    # capture stdin to send to serial port
-    try:
-        thread.start_new_thread(read_input, ())
-    except thread.error:
-        print("Error starting thread for read input\n")
+    if use_input:
+        # capture stdin to send to serial port
+        try:
+            thread.start_new_thread(read_input, ())
+        except thread.error:
+            print("Error starting thread for read input\n")
 
     # use stdout encoding, or "utf8" for output
     out_encoding = sys.stdout.encoding

--- a/putserial
+++ b/putserial
@@ -170,7 +170,7 @@ def grab(arglist, outputfd=sys.stdout):
     try:
         opts, args = getopt.getopt(
             arglist,
-            "hli:d:b:B:w:p:s:xrfc:E:taTF:m:e:o:AQvVq:nSC", [
+            "hli:d:b:B:w:p:s:xrfc:E:taTF:m:e:o:AQvVq:nNSC", [
                 "help",
                 "launchtime",
                 "inlinepat=",
@@ -198,6 +198,7 @@ def grab(arglist, outputfd=sys.stdout):
                 "version",
                 "quitpat=",
                 "nodelta",
+                "noinput",
                 "skip",
                 "crtonewline",
                 "command-mode",
@@ -242,6 +243,7 @@ def grab(arglist, outputfd=sys.stdout):
     quiet = False
     systime_format = "%H:%M:%S.%f"
     use_delta = True
+    use_input = True
     out_filenamehasdate = 0
 
     for opt, arg in opts:
@@ -358,6 +360,8 @@ Use 'grabserial -h' for usage help."""
             skip_device_check = 1
         if opt in ["-n", "--nodelta"]:
             use_delta = False
+        if opt in ["-N", "--noinput"]:
+            use_input = False
         if opt in ["--crtonewline"]:
             cr_to_nl = 1
 
@@ -462,11 +466,12 @@ Use 'grabserial -h' for usage help."""
         # Applies to both python 2 and 3 on Linux and Windows.
         stop_reason = "grabserial stopped due to a SerialException"
 
-    # capture stdin to send to serial port
-    try:
-        thread.start_new_thread(read_input, ())
-    except thread.error:
-        print("Error starting thread for read input\n")
+    if use_input:
+        # capture stdin to send to serial port
+        try:
+            thread.start_new_thread(read_input, ())
+        except thread.error:
+            print("Error starting thread for read input\n")
 
     stop_reason = "putserial stopped for an unknown reason"
     # read from the serial port until something stops the program


### PR DESCRIPTION
This is useful in scripts with command mode so that the program doesn't wait for standard input after the command has been sent.

For instance with the following the program hangs waiting for any input before exiting

```
user@host$ ./grabserial -d /dev/ttyUSB0  -q '>.*' --command="help"
help
test: run test
help: show this message
>
```

Instead, with the additional `--noinput` option the program exits immediately after the quit pattern is found:

```
user@host$ ./grabserial -d /dev/ttyUSB0  -q '>.*' --command="help" --noinput
help
test: run test
help: show this message
>
user@host$
```
